### PR TITLE
Using correct dependency name with underscores.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  flutter-floating-bottom-bar: ^1.2.0
+  flutter_floating_bottom_bar: ^1.2.0
 ```
 
 ### 2. Install it


### PR DESCRIPTION
Took me 5 mins as a flutter novice to figure out why adding dependency didn't work. Figured out it was due to hyphen instead of underscores. Using correct flutter dependency name now with underscores. 

Incorrect: flutter-floating-bottom-bar
Correct: flutter_floating_bottom_bar
