### PR TITLE
Fix for Unexpected white line on the Sample app TabBar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,6 +87,7 @@ class _MyHomePageState extends State<MyHomePage> with SingleTickerProviderStateM
             clipBehavior: Clip.none,
             children: [
               TabBar(
+                dividerColor: Colors.transparent,
                 indicatorPadding: const EdgeInsets.fromLTRB(6, 0, 6, 0),
                 controller: tabController,
                 indicator: UnderlineTabIndicator(


### PR DESCRIPTION
One-liner fix for the [issue](https://github.com/codenameakshay/flutter-floating-bottom-bar/issues/11) reported earlier today.