### PR TITLE
fix: keep back-to-top icon tappable with large iconOffset (#19)

### DIFF
--- a/lib/src/bottom_bar.dart
+++ b/lib/src/bottom_bar.dart
@@ -384,14 +384,19 @@ class _BottomBarState extends State<BottomBar>
     required Widget child,
     Offset translate = Offset.zero,
   }) {
-    final padded = Padding(padding: EdgeInsets.all(l.offset), child: child);
-    final translated = translate == Offset.zero
-        ? padded
-        : Transform.translate(offset: translate, child: padded);
-    return Align(
-      alignment: l.alignment,
-      child: l.respectSafeArea ? SafeArea(child: translated) : translated,
-    );
+    Widget content = Padding(padding: EdgeInsets.all(l.offset), child: child);
+    if (l.respectSafeArea) {
+      content = SafeArea(child: content);
+    }
+    // Translate outside the SafeArea/Padding so the offset wraps everything
+    // below it. Transform keeps hit-testing aligned with the painted position
+    // for its own subtree, so any size-checking ancestor (the SafeArea's
+    // RenderPadding) must sit beneath the Transform — otherwise large offsets
+    // move the icon outside its untranslated hit rect and taps stop landing.
+    if (translate != Offset.zero) {
+      content = Transform.translate(offset: translate, child: content);
+    }
+    return Align(alignment: l.alignment, child: content);
   }
 
   Widget _buildIcon(BottomBarThemeData theme) {

--- a/test/icon_offset_hit_test_test.dart
+++ b/test/icon_offset_hit_test_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_floating_bottom_bar/flutter_floating_bottom_bar.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget buildHarness(BottomBarController controller, Offset iconOffset) {
+    return MaterialApp(
+      home: Scaffold(
+        body: BottomBar(
+          controller: controller,
+          layout: BottomBarLayout(iconOffset: iconOffset),
+          body: ListView.builder(
+            itemCount: 200,
+            itemBuilder: (context, index) =>
+                ListTile(title: Text('Item $index')),
+          ),
+          child: const SizedBox(
+            height: 56,
+            child: Center(child: Text('Bottom Bar Child')),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Hides the bar (revealing the back-to-top icon), taps the icon at its
+  // rendered position, and reports whether the tap re-showed the bar.
+  Future<bool> tapBackToTopIcon(
+    WidgetTester tester,
+    BottomBarController controller,
+  ) async {
+    // Scroll down so the bar hides and a scroll position is recorded.
+    await tester.drag(find.byType(Scrollable).first, const Offset(0, -400));
+    await tester.pumpAndSettle();
+    expect(controller.isVisible, isFalse,
+        reason: 'bar should hide after scrolling down');
+
+    // Tap the icon at its actual rendered (translated) location.
+    await tester.tap(find.byTooltip('Scroll to top'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    return controller.isVisible;
+  }
+
+  testWidgets('back-to-top icon is tappable with a small iconOffset',
+      (tester) async {
+    final controller = BottomBarController();
+    await tester.pumpWidget(buildHarness(controller, const Offset(5, 0)));
+
+    expect(await tapBackToTopIcon(tester, controller), isTrue);
+  });
+
+  testWidgets('back-to-top icon is tappable with a large iconOffset',
+      (tester) async {
+    final controller = BottomBarController();
+    await tester.pumpWidget(buildHarness(controller, const Offset(100, 0)));
+
+    expect(
+      await tapBackToTopIcon(tester, controller),
+      isTrue,
+      reason: 'tapping the icon at a large offset should still register and '
+          'scroll the bar back into view',
+    );
+  });
+}


### PR DESCRIPTION
## Problem

Closes #19.

The back-to-top icon becomes unclickable when a large `iconOffset` (e.g. `Offset(100, 0)`) is set, while small offsets work fine. The icon is still painted in the right place — it just stops responding to taps.

## Root cause

In `_wrapWithSafeArea`, the icon was wrapped:

```
Align → SafeArea → Transform.translate(iconOffset) → Padding → icon
```

`Transform.translate` shifts where the icon *paints* and corrects hit-testing **only within its own subtree** — its layout box does not move. The `SafeArea` sits *above* the transform and is an ordinary `RenderPadding`, whose hit test does a `size.contains(position)` check against the icon's **untranslated** rect before descending.

- **Small offset** → the shifted icon still overlaps its original rect, so taps land. ✅
- **Large offset** → the visible icon moves entirely outside its original rect, so the `SafeArea` rejects the tap before it reaches the `InkWell`. ❌

## Fix

Move `Transform.translate` to wrap the `SafeArea` so it becomes the outermost child under `Align`. Every size-checking ancestor now sits *beneath* the transform and receives the transform-corrected hit position. The visual position is unchanged (a translate composes identically); only hit-testing is fixed. Zero-offset and the bar itself take an identical path to before.

## Tests

- Added `test/icon_offset_hit_test_test.dart` — taps the icon at a large offset and asserts the tap re-shows the bar. Fails before the fix, passes after.
- Full suite: 56/56 pass (incl. goldens). `flutter analyze`: no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)